### PR TITLE
Add note and link to documentation on the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Android mobile application for browsing OpenStreetMap features to create and edi
 
 ![OpenMapKit Flowchart](/docs/assets/OpenMapKit_flowchart.png)
 
+## Documentation
+
+See the [wiki](https://github.com/AmericanRedCross/openmapkit.git) for details on how to setup and load data into the app.
+
 ###License (GNU)
 
 See license [here](https://github.com/AmericanRedCross/openmapkit/blob/master/LICENSE.md).


### PR DESCRIPTION
As a newcomer to the app, I only saw the README and thought there was no documentation. Now I found some details on the wiki.

This adds a link from the README to the wiki, to help others more easily find some documentation.
