### PR TITLE
Fix vector reselection - Minor fix

### DIFF
--- a/app/src/main/java/org/redcross/openmapkit/OSMMapBuilder.java
+++ b/app/src/main/java/org/redcross/openmapkit/OSMMapBuilder.java
@@ -64,6 +64,8 @@ public class OSMMapBuilder extends AsyncTask<File, Long, JTSModel> {
         mapActivity = ma;
         sharedPreferences = mapActivity.getPreferences(Context.MODE_PRIVATE);
         persistedOSMFiles = sharedPreferences.getStringSet(PERSISTED_OSM_FILES, loadedOSMFiles);
+        // Allows selected files to be reloaded when map is recreated.
+        loadedOSMFiles.clear();
 
         // load the previously selected OSM files in OpenMapKit
         for (String absPath : persistedOSMFiles) {


### PR DESCRIPTION
https://github.com/AmericanRedCross/OpenMapKit/issues/60
https://github.com/onaio/OpenMapKit/issues/5
This clears the statically cached OSM files so that the files are reloaded and vectors get redrawn. This is basically what we've been doing on un-selecting and reselecting the OSM files.
