### PR TITLE
Select Multiple Tag Value Feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,9 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.1'
-    compile 'com.android.support:design:22.2.1'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile project(':MapboxAndroidSDK')
+    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:design:22.2.1'
+    compile 'com.android.support:support-v4:21.0.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.redcross.openmapkit"
         minSdkVersion 16
         targetSdkVersion 21
-        versionCode 14
-        versionName "0.14"
+        versionCode 15
+        versionName "0.15"
     }
     buildTypes {
         release {

--- a/app/src/main/java/org/redcross/openmapkit/odkcollect/tag/ODKTag.java
+++ b/app/src/main/java/org/redcross/openmapkit/odkcollect/tag/ODKTag.java
@@ -1,12 +1,15 @@
 package org.redcross.openmapkit.odkcollect.tag;
 
 import android.app.Activity;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,7 +20,8 @@ public class ODKTag {
     private String key;
     private String label;
     private LinkedHashMap<String, ODKTagItem> items = new LinkedHashMap<>();
-    private Map<Integer, ODKTagItem> radioButtonIdToODKTagItemHash = new HashMap<>();
+    private Map<Integer, ODKTagItem> buttonIdToODKTagItemHash = new HashMap<>();
+    private List<CheckBox> checkBoxes = new ArrayList<>();
 
     public String getKey() {
         return key;
@@ -47,12 +51,12 @@ public class ODKTag {
         items.put(item.getValue(), item);
     }
     
-    public void putRadioButtonIdToTagItemHash(Integer id, ODKTagItem tagItem) {
-        radioButtonIdToODKTagItemHash.put(id, tagItem);        
+    public void putButtonIdToTagItemHash(Integer id, ODKTagItem tagItem) {
+        buttonIdToODKTagItemHash.put(id, tagItem);
     }
     
-    public String getTagItemValueFromRadioButtonId(Integer id) {
-        ODKTagItem item = radioButtonIdToODKTagItemHash.get(id);
+    public String getTagItemValueFromButtonId(Integer id) {
+        ODKTagItem item = buttonIdToODKTagItemHash.get(id);
         if (item != null) {
             return item.getValue();
         }
@@ -75,5 +79,37 @@ public class ODKTag {
             et.setText(initialTagVal);
         }
         return et;
+    }
+
+    public void addCheckbox(CheckBox cb) {
+        checkBoxes.add(cb);
+    }
+
+    public boolean hasCheckedTagValues() {
+        for (CheckBox cb : checkBoxes) {
+            if (cb.isChecked()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public String getSemiColonDelimitedTagValues() {
+        String values = null;
+        boolean firstVal = true;
+        for (CheckBox cb : checkBoxes) {
+            if (cb.isChecked()) {
+                int id = cb.getId();
+                ODKTagItem item = buttonIdToODKTagItemHash.get(id);
+                if (item != null) {
+                    if (firstVal) {
+                        values = item.getValue();
+                    } else {
+                        values += ';' + item.getValue();
+                    }
+                }
+            }
+        }
+        return values;
     }
 }

--- a/app/src/main/java/org/redcross/openmapkit/odkcollect/tag/ODKTag.java
+++ b/app/src/main/java/org/redcross/openmapkit/odkcollect/tag/ODKTag.java
@@ -103,6 +103,7 @@ public class ODKTag {
                 ODKTagItem item = buttonIdToODKTagItemHash.get(id);
                 if (item != null) {
                     if (firstVal) {
+                        firstVal = false;
                         values = item.getValue();
                     } else {
                         values += ';' + item.getValue();

--- a/app/src/main/java/org/redcross/openmapkit/odkcollect/tag/ODKTag.java
+++ b/app/src/main/java/org/redcross/openmapkit/odkcollect/tag/ODKTag.java
@@ -94,7 +94,7 @@ public class ODKTag {
         return false;
     }
 
-    public String getSemiColonDelimitedTagValues() {
+    public String getSemiColonDelimitedTagValues(String customValues) {
         String values = null;
         boolean firstVal = true;
         for (CheckBox cb : checkBoxes) {
@@ -108,6 +108,16 @@ public class ODKTag {
                     } else {
                         values += ';' + item.getValue();
                     }
+                }
+            }
+        }
+        if (customValues != null) {
+            customValues = customValues.trim();
+            if (customValues.length() > 0) {
+                if (firstVal) {
+                    values = customValues;
+                } else {
+                    values += ';' + customValues;
                 }
             }
         }

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -78,6 +78,7 @@ public class SelectMultipleTagValueFragment extends Fragment {
         String prevTagVal = tagEdit.getTagVal();
         boolean prevTagValInTagItems = false;
         Collection<ODKTagItem> odkTagItems = odkTag.getItems();
+        int id = 1;
         for (ODKTagItem item : odkTagItems) {
             String label = item.getLabel();
             String value = item.getValue();
@@ -100,8 +101,8 @@ public class SelectMultipleTagValueFragment extends Fragment {
             if (prevTagVal != null && value.equals(prevTagVal)) {
                 checkBox.toggle();
             }
-            int id = checkBox.getId();
-            odkTag.putButtonIdToTagItemHash(id, item);
+            checkBox.setId(id);
+            odkTag.putButtonIdToTagItemHash(id++, item);
             odkTag.addCheckbox(checkBox);
             checkboxLinearLayout.addView(textView);
         }

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -1,13 +1,18 @@
 package org.redcross.openmapkit.tagswipe;
 
 import android.app.Activity;
+import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -65,6 +70,7 @@ public class SelectMultipleTagValueFragment extends Fragment {
         setupCheckBoxes();
     }
 
+    @SuppressWarnings("ResourceType")
     private void setupCheckBoxes() {
         tagEdit.setCheckBoxMode(true);
         final LinearLayout checkboxLinearLayout = (LinearLayout)rootView.findViewById(R.id.checkboxLinearLayout);
@@ -106,6 +112,54 @@ public class SelectMultipleTagValueFragment extends Fragment {
             odkTag.addCheckbox(checkBox);
             checkboxLinearLayout.addView(textView);
         }
+
+        final CheckBox editTextCheckBox = new CheckBox(activity);
+        final EditText editText = new EditText(activity);
+        editText.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        if (!prevTagValInTagItems && prevTagVal != null) {
+            editText.setText(prevTagVal);
+            editTextCheckBox.setChecked(true);
+        }
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                if (charSequence.length() > 0) {
+                    editTextCheckBox.setChecked(true);
+                } else {
+                    editTextCheckBox.setChecked(false);
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+            }
+        });
+        editTextCheckBox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (editTextCheckBox.isChecked()) {
+                    editText.setFocusableInTouchMode(true);
+                    editText.requestFocus();
+                    final InputMethodManager inputMethodManager = (InputMethodManager) activity
+                            .getSystemService(Context.INPUT_METHOD_SERVICE);
+                    inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                }
+            }
+        });
+
+        LinearLayout customLinearLayout = new LinearLayout(activity);
+        customLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
+        customLinearLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        customLinearLayout.setDescendantFocusability(ViewGroup.FOCUS_BEFORE_DESCENDANTS);
+        customLinearLayout.setFocusableInTouchMode(true);
+        customLinearLayout.addView(editTextCheckBox);
+        customLinearLayout.addView(editText);
+        checkboxLinearLayout.addView(customLinearLayout);
+
     }
 
     /**

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -7,6 +7,7 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import org.redcross.openmapkit.R;
 
@@ -41,6 +42,24 @@ public class SelectMultipleTagValueFragment extends Fragment {
     }
 
     private void setupWidgets() {
+        TextView tagKeyLabelTextView = (TextView) rootView.findViewById(R.id.tagKeyLabelTextView);
+        TextView tagKeyTextView = (TextView) rootView.findViewById(R.id.tagKeyTextView);
+
+        String keyLabel = tagEdit.getTagKeyLabel();
+        String key = tagEdit.getTagKey();
+
+        if (keyLabel != null) {
+            tagKeyLabelTextView.setText(keyLabel);
+            tagKeyTextView.setText(key);
+        } else {
+            tagKeyLabelTextView.setText(key);
+            tagKeyTextView.setText("");
+        }
+
+        setupCheckBoxes();
+    }
+
+    private void setupCheckBoxes() {
 
     }
 

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -66,6 +66,7 @@ public class SelectMultipleTagValueFragment extends Fragment {
     }
 
     private void setupCheckBoxes() {
+        tagEdit.setCheckBoxMode(true);
         final LinearLayout checkboxLinearLayout = (LinearLayout)rootView.findViewById(R.id.checkboxLinearLayout);
         final Activity activity = getActivity();
         ODKTag odkTag = tagEdit.getODKTag();
@@ -99,6 +100,9 @@ public class SelectMultipleTagValueFragment extends Fragment {
             if (prevTagVal != null && value.equals(prevTagVal)) {
                 checkBox.toggle();
             }
+            int id = checkBox.getId();
+            odkTag.putButtonIdToTagItemHash(id, item);
+            odkTag.addCheckbox(checkBox);
             checkboxLinearLayout.addView(textView);
         }
     }

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -72,7 +72,6 @@ public class SelectMultipleTagValueFragment extends Fragment {
 
     @SuppressWarnings("ResourceType")
     private void setupCheckBoxes() {
-        tagEdit.setCheckBoxMode(true);
         final LinearLayout checkboxLinearLayout = (LinearLayout)rootView.findViewById(R.id.checkboxLinearLayout);
         final Activity activity = getActivity();
         ODKTag odkTag = tagEdit.getODKTag();
@@ -150,6 +149,7 @@ public class SelectMultipleTagValueFragment extends Fragment {
                 }
             }
         });
+        tagEdit.setupEditCheckbox(editTextCheckBox, editText);
 
         LinearLayout customLinearLayout = new LinearLayout(activity);
         customLinearLayout.setOrientation(LinearLayout.HORIZONTAL);

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -1,0 +1,92 @@
+package org.redcross.openmapkit.tagswipe;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.redcross.openmapkit.R;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Activities that contain this fragment must implement the
+ * {@link SelectMultipleTagValueFragment.OnFragmentInteractionListener} interface
+ * to handle interaction events.
+ * Use the {@link SelectMultipleTagValueFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class SelectMultipleTagValueFragment extends Fragment {
+
+    private static final String IDX = "IDX";
+
+    private TagEdit tagEdit;
+    private View rootView;
+
+    private OnFragmentInteractionListener mListener;
+
+    public SelectMultipleTagValueFragment() {
+        // Required empty public constructor
+    }
+
+
+    public static SelectMultipleTagValueFragment newInstance(int idx) {
+        SelectMultipleTagValueFragment fragment = new SelectMultipleTagValueFragment();
+        Bundle args = new Bundle();
+        args.putInt(IDX, idx);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    private void setupWidgets() {
+
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            int idx = getArguments().getInt(IDX);
+            tagEdit = TagEdit.getTag(idx);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        rootView = inflater.inflate(R.layout.fragment_select_multiple_tag_value, container, false);
+        setupWidgets();
+        return rootView;
+    }
+
+    // TODO: Rename method, update argument and hook method into UI event
+    public void onButtonPressed(Uri uri) {
+        if (mListener != null) {
+            mListener.onFragmentInteraction(uri);
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mListener = null;
+    }
+
+    /**
+     * This interface must be implemented by activities that contain this
+     * fragment to allow an interaction in this fragment to be communicated
+     * to the activity and potentially other fragments contained in that
+     * activity.
+     * <p/>
+     * See the Android Training lesson <a href=
+     * "http://developer.android.com/training/basics/fragments/communicating.html"
+     * >Communicating with Other Fragments</a> for more information.
+     */
+    public interface OnFragmentInteractionListener {
+        // TODO: Update argument type and name
+        void onFragmentInteraction(Uri uri);
+    }
+}

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectMultipleTagValueFragment.java
@@ -1,15 +1,21 @@
 package org.redcross.openmapkit.tagswipe;
 
-import android.content.Context;
+import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.redcross.openmapkit.R;
+import org.redcross.openmapkit.odkcollect.tag.ODKTag;
+import org.redcross.openmapkit.odkcollect.tag.ODKTagItem;
+
+import java.util.Collection;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -60,7 +66,57 @@ public class SelectMultipleTagValueFragment extends Fragment {
     }
 
     private void setupCheckBoxes() {
+        final LinearLayout checkboxLinearLayout = (LinearLayout)rootView.findViewById(R.id.checkboxLinearLayout);
+        final Activity activity = getActivity();
+        ODKTag odkTag = tagEdit.getODKTag();
+        if (odkTag == null) return;
 
+        /**
+         * Setting up buttons with prescribed choice values.
+         */
+        String prevTagVal = tagEdit.getTagVal();
+        boolean prevTagValInTagItems = false;
+        Collection<ODKTagItem> odkTagItems = odkTag.getItems();
+        for (ODKTagItem item : odkTagItems) {
+            String label = item.getLabel();
+            String value = item.getValue();
+            if (value.equals(prevTagVal)) {
+                prevTagValInTagItems = true;
+            }
+            CheckBox checkBox = new CheckBox(activity);
+            checkBox.setTextSize(18);
+            TextView textView = new TextView(activity);
+            textView.setPadding(66, 0, 0, 25);
+            textView.setOnClickListener(new TextViewOnClickListener(checkBox));
+            if (label != null) {
+                checkBox.setText(label);
+                textView.setText(value);
+            } else {
+                checkBox.setText(value);
+                textView.setText("");
+            }
+            checkboxLinearLayout.addView(checkBox);
+            if (prevTagVal != null && value.equals(prevTagVal)) {
+                checkBox.toggle();
+            }
+            checkboxLinearLayout.addView(textView);
+        }
+    }
+
+    /**
+     * Allows us to pass a CheckBox as a parameter to onClick
+     */
+    private class TextViewOnClickListener implements View.OnClickListener {
+        CheckBox checkBox;
+
+        public TextViewOnClickListener(CheckBox cb) {
+            checkBox = cb;
+        }
+
+        @Override
+        public void onClick(View v) {
+            checkBox.toggle();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectOneTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectOneTagValueFragment.java
@@ -147,8 +147,8 @@ public class SelectOneTagValueFragment extends Fragment {
             if (prevTagVal != null && value.equals(prevTagVal)) {
                 button.toggle();
             }
-            int buttonId = button.getId();
-            odkTag.putRadioButtonIdToTagItemHash(buttonId, item);
+            int id = button.getId();
+            odkTag.putButtonIdToTagItemHash(id, item);
             tagValueRadioGroup.addView(textView);
         }
         if (!prevTagValInTagItems) {

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectOneTagValueFragment.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/SelectOneTagValueFragment.java
@@ -1,6 +1,5 @@
 package org.redcross.openmapkit.tagswipe;
 
-import android.app.ActionBar;
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
@@ -11,7 +10,6 @@ import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewParent;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -40,9 +38,6 @@ public class SelectOneTagValueFragment extends Fragment {
     private TagEdit tagEdit;
     private View rootView;
 
-    private TextView tagKeyLabelTextView;
-    private TextView tagKeyTextView;
-
     private OnFragmentInteractionListener mListener;
 
     
@@ -55,8 +50,8 @@ public class SelectOneTagValueFragment extends Fragment {
     }
 
     private void setupWidgets() {
-        tagKeyLabelTextView = (TextView)rootView.findViewById(R.id.tagKeyLabelTextView);
-        tagKeyTextView = (TextView)rootView.findViewById(R.id.tagKeyTextView);
+        TextView tagKeyLabelTextView = (TextView) rootView.findViewById(R.id.tagKeyLabelTextView);
+        TextView tagKeyTextView = (TextView) rootView.findViewById(R.id.tagKeyTextView);
 
         String keyLabel = tagEdit.getTagKeyLabel();
         String key = tagEdit.getTagKey();

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
@@ -35,6 +35,7 @@ public class TagEdit {
     private String tagVal;
     private ODKTag odkTag;
     private boolean readOnly;
+    private boolean checkBoxMode = false;
     private int idx = -1;
     private EditText editText;
     private RadioGroup radioGroup;
@@ -135,12 +136,27 @@ public class TagEdit {
     public void setRadioGroup(RadioGroup radioGroup) {
         this.radioGroup = radioGroup;
     }
+
+    public void setCheckBoxMode(boolean bool) {
+        checkBoxMode = true;
+    }
     
     public ODKTag getODKTag() {
         return odkTag;
     }
     
     private void updateTagInOSMElement() {
+        // check boxes
+        if (odkTag != null && checkBoxMode) {
+            if (odkTag.hasCheckedTagValues()) {
+                tagVal = odkTag.getSemiColonDelimitedTagValues();
+                osmElement.addOrEditTag(tagKey, tagVal);
+            } else {
+                osmElement.deleteTag(tagKey);
+            }
+            return;
+        }
+        // radio buttons
         if (radioGroup != null && odkTag != null) {
             LinearLayout customLL = (LinearLayout)radioGroup.getChildAt(radioGroup.getChildCount() - 1);
             RadioButton customRadio = (RadioButton)customLL.getChildAt(0);
@@ -150,12 +166,14 @@ public class TagEdit {
                 tagVal = et.getText().toString();
                 osmElement.addOrEditTag(tagKey, tagVal);
             } else if (checkedId != -1) {
-                tagVal = odkTag.getTagItemValueFromRadioButtonId(checkedId);
+                tagVal = odkTag.getTagItemValueFromButtonId(checkedId);
                 osmElement.addOrEditTag(tagKey, tagVal);
             } else {
                 osmElement.deleteTag(tagKey);
             }
-        } else if (editText != null) {
+        }
+        // edit text
+        else if (editText != null) {
             tagVal = editText.getText().toString();
             osmElement.addOrEditTag(tagKey, tagVal);
         }

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
@@ -157,8 +157,9 @@ public class TagEdit {
     private void updateTagInOSMElement() {
         // check boxes
         if (odkTag != null && checkBoxMode) {
-            if (odkTag.hasCheckedTagValues()) {
-                if (editTextCheckBox.isChecked()) {
+            boolean editTextCheckBoxChecked = editTextCheckBox.isChecked();
+            if (odkTag.hasCheckedTagValues() || editTextCheckBoxChecked) {
+                if (editTextCheckBoxChecked) {
                     tagVal = odkTag.getSemiColonDelimitedTagValues(checkBoxEditText.getText().toString());
                 } else {
                     tagVal = odkTag.getSemiColonDelimitedTagValues(null);

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/TagEdit.java
@@ -1,5 +1,6 @@
 package org.redcross.openmapkit.tagswipe;
 
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
@@ -39,6 +40,12 @@ public class TagEdit {
     private int idx = -1;
     private EditText editText;
     private RadioGroup radioGroup;
+
+    /**
+     * For CheckBox mode.
+     */
+    private CheckBox editTextCheckBox;
+    private EditText checkBoxEditText;
     
     public static List<TagEdit> buildTagEdits() {
         int idx = 0;
@@ -137,8 +144,10 @@ public class TagEdit {
         this.radioGroup = radioGroup;
     }
 
-    public void setCheckBoxMode(boolean bool) {
+    public void setupEditCheckbox(CheckBox cb, EditText et) {
         checkBoxMode = true;
+        editTextCheckBox = cb;
+        checkBoxEditText = et;
     }
     
     public ODKTag getODKTag() {
@@ -149,7 +158,11 @@ public class TagEdit {
         // check boxes
         if (odkTag != null && checkBoxMode) {
             if (odkTag.hasCheckedTagValues()) {
-                tagVal = odkTag.getSemiColonDelimitedTagValues();
+                if (editTextCheckBox.isChecked()) {
+                    tagVal = odkTag.getSemiColonDelimitedTagValues(checkBoxEditText.getText().toString());
+                } else {
+                    tagVal = odkTag.getSemiColonDelimitedTagValues(null);
+                }
                 osmElement.addOrEditTag(tagKey, tagVal);
             } else {
                 osmElement.deleteTag(tagKey);

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/TagSwipeActivity.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/TagSwipeActivity.java
@@ -178,8 +178,8 @@ public class TagSwipeActivity extends ActionBarActivity {
                         fragment = ReadOnlyTagFragment.newInstance(position);
                         return fragment;
                     } else if (tagEdit.isSelectOne()) {
-//                        fragment = SelectOneTagValueFragment.newInstance(position);
-                        fragment = SelectMultipleTagValueFragment.newInstance(position);
+                        fragment = SelectOneTagValueFragment.newInstance(position);
+//                        fragment = SelectMultipleTagValueFragment.newInstance(position);
                         return fragment;
                     } else {
                         fragment = StringTagValueFragment.newInstance(position);

--- a/app/src/main/java/org/redcross/openmapkit/tagswipe/TagSwipeActivity.java
+++ b/app/src/main/java/org/redcross/openmapkit/tagswipe/TagSwipeActivity.java
@@ -178,7 +178,8 @@ public class TagSwipeActivity extends ActionBarActivity {
                         fragment = ReadOnlyTagFragment.newInstance(position);
                         return fragment;
                     } else if (tagEdit.isSelectOne()) {
-                        fragment = SelectOneTagValueFragment.newInstance(position);
+//                        fragment = SelectOneTagValueFragment.newInstance(position);
+                        fragment = SelectMultipleTagValueFragment.newInstance(position);
                         return fragment;
                     } else {
                         fragment = StringTagValueFragment.newInstance(position);

--- a/app/src/main/res/layout/fragment_select_multiple_tag_value.xml
+++ b/app/src/main/res/layout/fragment_select_multiple_tag_value.xml
@@ -1,0 +1,13 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.redcross.openmapkit.tagswipe.SelectMultipleTagValueFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_select_multiple_tag_value.xml
+++ b/app/src/main/res/layout/fragment_select_multiple_tag_value.xml
@@ -34,7 +34,15 @@
         <ScrollView
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:id="@+id/scrollView" />
+            android:id="@+id/scrollView">
+
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:id="@+id/checkboxLinearLayout" />
+
+        </ScrollView>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_select_multiple_tag_value.xml
+++ b/app/src/main/res/layout/fragment_select_multiple_tag_value.xml
@@ -4,10 +4,38 @@
     android:layout_height="match_parent"
     tools:context="org.redcross.openmapkit.tagswipe.SelectMultipleTagValueFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:paddingLeft="20dp"
+        android:paddingTop="20dp"
+        android:paddingRight="20dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            android:text="tagKeyLabel"
+            android:id="@+id/tagKeyLabelTextView" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:text="tagKey"
+            android:id="@+id/tagKeyTextView"
+            android:textStyle="italic" />
+
+        <Space
+            android:layout_width="20px"
+            android:layout_height="@dimen/abc_text_size_large_material" />
+
+        <ScrollView
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:id="@+id/scrollView" />
+
+    </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="save">Save</string>
     <string name="cancel">Cancel</string>
     <string name="add">+</string>
-    
+
     <string name="mbtilesAppPath">openmapkit/mbtiles</string>
 
     <!-- private shared preferences for mapactivity -->
@@ -58,9 +58,9 @@
     <string name="title_activity_tag_swipe">Tags</string>
 
 
-<!-- TODO: Remove or change this placeholder text -->
+    <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
-    
+
     <string name="odkcollect_fragment_title">Confirm</string>
     <string name="odkcollect_fragment_question">Save tag edits to ODK Collect?</string>
     <string name="standalone_fragment_title">Add or Confirm</string>


### PR DESCRIPTION
If you check out tag `0.15`, you can use check boxes instead of radio buttons for your selection questions. Rather than being able to select one single tag value, you can select multiple, and they will be semi-colon delimited.

This is enabled only on tag `0.15` and the `select-multiple-tag-value` branch. You can turn on and off this functionality in the code here:

https://github.com/AmericanRedCross/OpenMapKitAndroid/blob/f280d73d94d6bd4f5dfda58e936a63d51f4fb609/app/src/main/java/org/redcross/openmapkit/tagswipe/TagSwipeActivity.java#L182

Once we get the whole [constraint workflow](https://github.com/AmericanRedCross/OpenMapKitAndroid/issues/117) figured out, we will be able to specify if we want to select one or multiple tag values. There's a bit to sort out with that, so this is why we have the temporary v0.15 APK.
