### PR TITLE
Keep track of previous tag and undo tags that were shown or hidden if…

### DIFF
--- a/app/src/main/java/org/redcross/openmapkit/Constraints.java
+++ b/app/src/main/java/org/redcross/openmapkit/Constraints.java
@@ -361,7 +361,7 @@ public class Constraints {
         }
     }
 
-    private Set<String> findTagsToBeHiddenFromUpdate(String key, String val) {
+    public Set<String> findTagsToBeHiddenFromUpdate(String key, String val) {
         Set<String> tags = new HashSet<>();
 
         Map<String, Set<String>> causeHideMapMap = causeHideMap.get(key);
@@ -390,7 +390,7 @@ public class Constraints {
         return tags;
     }
 
-    private Set<String> findTagsToBeShownFromUpdate(String key, String val) {
+    public Set<String> findTagsToBeShownFromUpdate(String key, String val) {
         Set<String> tags = new HashSet<>();
 
         Map<String, Set<String>> causeShowMapMap = causeShowMap.get(key);


### PR DESCRIPTION
Fixes a bug when tags are hidden as part of a field constraint, if a user changes their mind, the tag is not re-shown, but remains hidden.  Part of HotOSM OMK upgrade project.

c.c. @smit1678